### PR TITLE
simular una respuesta predeterminada cada vez que Jest vea una imagen…

### DIFF
--- a/mocks/fileMock.js
+++ b/mocks/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/package.json
+++ b/package.json
@@ -48,5 +48,11 @@
   },
   "dependencies": {
     "firebase": "^9.17.2"
-  }
+  },
+  "jest": {
+    "moduleNameMapper": {
+         "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/fileMock.js",
+         "\\.(css|less)$": "<rootDir>/mocks/fileMock.js"
+       }
+   }
 }


### PR DESCRIPTION
Cuando importa archivos de imagen, Jest intenta interpretar los códigos binarios de las imágenes como .js, por lo que se encuentra con errores. ¡La única salida es simular una respuesta predeterminada cada vez que Jest vea una imagen importada!